### PR TITLE
Enabled Physics and collision for trees

### DIFF
--- a/game/levels/level_01/sm_meda_terrain.gltf.import
+++ b/game/levels/level_01/sm_meda_terrain.gltf.import
@@ -33,11 +33,38 @@ animation/import_rest_as_RESET=false
 import_script/path=""
 _subresources={
 "nodes": {
-"PATH:Terrain": {
-"generate/physics": true
+"PATH:Terrain_1": {
+"generate/physics": true,
+"physics/layer": 2,
+"physics/mask": 0,
+"physics/shape_type": 2
 },
-"PATH:Walls": {
-"generate/physics": true
+"PATH:Terrain_2": {
+"generate/physics": true,
+"physics/layer": 2,
+"physics/mask": 0,
+"physics/shape_type": 2
+},
+"PATH:Terrain_3": {
+"generate/physics": true,
+"physics/layer": 2,
+"physics/mask": 0,
+"physics/shape_type": 2
+},
+"PATH:Walls_1": {
+"generate/physics": true,
+"physics/mask": 0,
+"physics/shape_type": 2
+},
+"PATH:Walls_2": {
+"generate/physics": true,
+"physics/mask": 0,
+"physics/shape_type": 2
+},
+"PATH:Walls_3": {
+"generate/physics": true,
+"physics/mask": 0,
+"physics/shape_type": 2
 }
 }
 }

--- a/game/levels/level_01/sm_meda_terrain_objects.gltf.import
+++ b/game/levels/level_01/sm_meda_terrain_objects.gltf.import
@@ -31,6 +31,90 @@ animation/trimming=false
 animation/remove_immutable_tracks=true
 animation/import_rest_as_RESET=false
 import_script/path=""
-_subresources={}
+_subresources={
+"nodes": {
+"PATH:Tree_1": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0,
+"physics/shape_type": 2
+},
+"PATH:Tree_10": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_11": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_12": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_13": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_14": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_15": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_16": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_2": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_3": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_4": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_5": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_6": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_7": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_8": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+},
+"PATH:Tree_9": {
+"generate/physics": true,
+"physics/layer": 4,
+"physics/mask": 0
+}
+}
+}
 gltf/naming_version=1
 gltf/embedded_image_handling=1

--- a/test/test_altar_locations/test_melee_altar_location.tscn
+++ b/test/test_altar_locations/test_melee_altar_location.tscn
@@ -9,8 +9,7 @@
 [node name="MeleeAltarLocation" parent="." instance=ExtResource("1_607v6")]
 
 [node name="PlayerCharacter" parent="." instance=ExtResource("2_87s17")]
-transform = Transform3D(0.93495, 0, 0.35478, 0, 1, 0, -0.35478, 0, 0.93495, 0, 0, 0)
+transform = Transform3D(0.236754, 0, 0.97157, 0, 1, 0, -0.97157, 0, 0.236754, 7.07198, 0.593104, 0)
 melee_attack_cooldown = 1.0
-max_health = 100.0
 
 [node name="Level01Environment" parent="." instance=ExtResource("3_rt8gv")]


### PR DESCRIPTION
Enabled Physics on sm_meda_terrain and moved the player character in the initial spawn area (character was falling out). Also added collision to trees.

### ↑↑ Commit Comment Appears Here ↑↑


# *Pull Request Template*

## *Art Models*
##### Checklist:
- [x] Attach Image || Video.
- [x] @mention issue(s) (if any) this issue is related to.
- [x] @mention the issue this closes

# Image/Video
![image](https://github.com/user-attachments/assets/6f52d4cb-2000-4c18-a8c3-d83741d1d3ad)



# Related Issues



# Does this close any issues?


